### PR TITLE
Update CI matrix to remove macOS 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
       matrix:
         include:
           - ghc: '9.10'
-            os: macos-13
-          - ghc: '9.10'
             os: macos-14
           - ghc: 9.6
             os: ubuntu-22.04


### PR DESCRIPTION
Removed macOS 13 from the CI matrix.